### PR TITLE
Use new way of loading v2 widgets

### DIFF
--- a/root/src/config.json
+++ b/root/src/config.json
@@ -37,7 +37,6 @@
     "js_files": [
         "js/{%= jsname %}.js"
     ],
-    "entrypoint": "js/{%= entrypoint %}.js",
     "title": "{%= project_name %}",
     "translations": {},
     "type": "widget",

--- a/root/src/config.xml
+++ b/root/src/config.xml
@@ -32,7 +32,6 @@
     <scripts>
         <script src="js/{%= jsname %}.js"/>
     </scripts>
-    <entrypoint name="{%= entrypoint %}"/>
     <rendering height="300px" width="30%"/>
 
 </widget>

--- a/root/src/js/name.js
+++ b/root/src/js/name.js
@@ -25,7 +25,12 @@
         }
     }
 
-    Wirecloud.registerWidgetClass(script, Widget);
+    if (!('Wirecloud' in window)) {
+        // For testing purposes
+        window.Widget = Widget;
+    } else {
+        Wirecloud.registerWidgetClass(script, Widget);
+    }
 
     /* test-code */
 

--- a/root/src/js/name.js
+++ b/root/src/js/name.js
@@ -6,9 +6,7 @@
  * Licensed under the {%= licenses.join(', ') %} license{%= licenses.length === 1 ? '' : 's' %}.
  */
 
-/* exported {%= entrypoint %} */
-
-(function () {
+(function (script) {
 
     "use strict";
 
@@ -16,7 +14,7 @@
     // CLASS DEFINITION
     // =========================================================================
 
-    class {%= entrypoint %} {
+    class Widget {
         constructor(MashupPlatform, shadowDOM, extra) {
             this.MashupPlatform = MashupPlatform;
             this.shadowDOM = shadowDOM;
@@ -27,11 +25,10 @@
         }
     }
 
-    // We define the class as part of the window object so that it can be instantiated by Wirecloud
-    window.{%= entrypoint %} = {%= entrypoint %};
+    Wirecloud.registerWidgetClass(script, Widget);
 
     /* test-code */
 
     /* end-test-code */
 
-})();
+})(document.currentScript);

--- a/root/src/ts/name.ts
+++ b/root/src/ts/name.ts
@@ -9,7 +9,7 @@ import MashupPlatform = require("MashupPlatform");
 {% if (ngsi) { %}import NGSI = require("NGSI");{% }%}
 /* end-import-block */
 
-export class {%= entrypoint %} {
+export class Widget {
     private MashupPlatform: MashupPlatform;
     private shadowDOM: any;
     {% if (ngsi) { %}private NGSI: NGSI;{% }%}
@@ -27,5 +27,4 @@ export class {%= entrypoint %} {
     }
 }
 
-// We define the class as part of the window object so that it can be instantiated by Wirecloud
-(<any>window)["{%= entrypoint %}"] = {%= entrypoint %};
+(<any>Wirecloud).registerWidgetClass((<any>document).currentScript, Widget);

--- a/root/src/ts/name.ts
+++ b/root/src/ts/name.ts
@@ -27,4 +27,8 @@ export class Widget {
     }
 }
 
-(<any>Wirecloud).registerWidgetClass((<any>document).currentScript, Widget);
+if (!(<any>window).Wirecloud) {
+    (<any>window).Widget = Widget;
+} else {
+    (<any>window).Wirecloud.registerWidgetClass((<any>document).currentScript, Widget);
+}

--- a/root/tests/js/nameSpec.js
+++ b/root/tests/js/nameSpec.js
@@ -6,7 +6,7 @@
  * Licensed under the {%= licenses.join(', ') %} license{%= licenses.length === 1 ? '' : 's' %}.
  */
 
-/* globals $, MashupPlatform, MockMP, {%= entrypoint %} */
+/* globals $, MashupPlatform, MockMP */
 
 (function () {
 
@@ -16,16 +16,23 @@
 
         var widget;
         var MashupPlatform;
+        var Widget;
 
         beforeAll(function () {
             MashupPlatform = new MockMP({
                 type: 'widget'
             });
+
+            window.Wirecloud = {
+                registerWidgetClass: function (script, widgetClass) {
+                    Widget = widgetClass;
+                }
+            }
         });
 
         beforeEach(function () {
             MashupPlatform.reset();
-            widget = new {%= entrypoint %}(MashupPlatform, undefined, {});
+            widget = new Widget(MashupPlatform, undefined, {});
         });
 
         it("Dummy test", function () {

--- a/root/tests/js/nameSpec.js
+++ b/root/tests/js/nameSpec.js
@@ -23,11 +23,7 @@
                 type: 'widget'
             });
 
-            window.Wirecloud = {
-                registerWidgetClass: function (script, widgetClass) {
-                    Widget = widgetClass;
-                }
-            }
+            Widget = window.Widget;
         });
 
         beforeEach(function () {

--- a/template.js
+++ b/template.js
@@ -51,14 +51,6 @@ var capitalizeAndRemoveUnderscore = function capitalizeAndRemoveUnderscore(old) 
     return t.charAt(0).toUpperCase() + t.slice(1);
 };
 
-var getEntrypointName = function getEntrypointName(vendor, name, version) {
-    // Remove all non-alphanumeric characters. Replace spaces with underscores.
-    vendor = vendor.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
-    name = name.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
-    version = version.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
-    return vendor + '_' + name + '_' + version;
-}
-
 // The actual init template.
 exports.template = function(grunt, init, done) {
     init.process([
@@ -131,7 +123,6 @@ exports.template = function(grunt, init, done) {
     ], function(err, props){
         var exportsOverride = {};
         props.jsname = capitalizeAndRemoveUnderscore(props.name);
-        props.entrypoint = getEntrypointName(props.vendor, props.name, props.version);
         props.bower = true; // Change way to determine bower?
         props.ngsi = false; // ??
         var bowerdeps = {};

--- a/template.js
+++ b/template.js
@@ -51,11 +51,12 @@ var capitalizeAndRemoveUnderscore = function capitalizeAndRemoveUnderscore(old) 
     return t.charAt(0).toUpperCase() + t.slice(1);
 };
 
-var getEntrypointName = function getEntrypointName(vendor, name) {
+var getEntrypointName = function getEntrypointName(vendor, name, version) {
     // Remove all non-alphanumeric characters. Replace spaces with underscores.
     vendor = vendor.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
     name = name.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
-    return vendor + '_' + name;
+    version = version.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
+    return vendor + '_' + name + '_' + version;
 }
 
 // The actual init template.
@@ -130,7 +131,7 @@ exports.template = function(grunt, init, done) {
     ], function(err, props){
         var exportsOverride = {};
         props.jsname = capitalizeAndRemoveUnderscore(props.name);
-        props.entrypoint = getEntrypointName(props.vendor, props.name);
+        props.entrypoint = getEntrypointName(props.vendor, props.name, props.version);
         props.bower = true; // Change way to determine bower?
         props.ngsi = false; // ??
         var bowerdeps = {};


### PR DESCRIPTION
Uses the new `registerWidgetClass` function to load v2 widgets. To be merged after Wirecloud/wirecloud#542.